### PR TITLE
Remove diagnostic NGD1002

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -42,11 +42,8 @@ namespace NativeGenericDelegatesGenerator
         public const string SourceFileName = RootNamespace + ".g.cs";
 
         public const string MarshalAsArgumentMustUseObjectCreationSyntaxID = "NGD1001";
-        public const string InvalidMarshalParamsAsArrayLengthID = "NGD1002";
         public static readonly DiagnosticDescriptor MarshalAsArgumentMustUseObjectCreationSyntaxDescriptor =
             new(MarshalAsArgumentMustUseObjectCreationSyntaxID, "Invalid MarshalAs argument", "MarshalAs argument must be null or use object creation syntax", "Usage", DiagnosticSeverity.Error, true);
-        public static readonly DiagnosticDescriptor InvalidMarshalParamsAsArrayLengthDescriptor =
-            new(InvalidMarshalParamsAsArrayLengthID, $"Invalid marshalParamsAs argument", $"marshalParamsAs argument must be array of correct length", "Usage", DiagnosticSeverity.Error, true);
 
         public static readonly string[] GenericActionTypeParameters = new[]
         {

--- a/NativeGenericDelegateInfo.cs
+++ b/NativeGenericDelegateInfo.cs
@@ -132,7 +132,8 @@ namespace NativeGenericDelegatesGenerator
                 FunctionPointerTypeArgumentsWithReturnType += ", void";
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _ = sb.Append(andNewLine).Append($"MarshalInfo.Equals({(isAction ? "null" : "marshalReturnAs")}, marshalParamsAs, {marshalReturnAsAttribute}, {marshalParamsAsAttributes})");
+            _ = sb.Append(andNewLine).Append($"MarshalInfo.Equals({(isAction ? "null" : "marshalReturnAs")}, {marshalReturnAsAttribute})")
+                .Append(andNewLine).Append($"MarshalInfo.PartiallyEquals(marshalParamsAs, {marshalParamsAsAttributes})");
             TypeArgumentCheckWithMarshalInfoCondition = sb.ToString();
         }
     }

--- a/PartialImplementations.cs
+++ b/PartialImplementations.cs
@@ -188,35 +188,7 @@ namespace {Constants.RootNamespace}
 {{
     file static class MarshalInfo
     {{
-        internal static bool Equals(MarshalAsAttribute? marshalReturnAsLeft, MarshalAsAttribute?[]? marshalParamsAsLeft, MarshalAsAttribute? marshalReturnAsRight, MarshalAsAttribute?[]? marshalParamsAsRight)
-        {{
-            if (!Equals(marshalReturnAsLeft, marshalReturnAsRight))
-            {{
-                return false;
-            }}
-            if (marshalParamsAsLeft is null)
-            {{
-                return marshalParamsAsRight is null;
-            }}
-            else if (marshalParamsAsRight is null)
-            {{
-                return false;
-            }}
-            if (marshalParamsAsLeft.Length != marshalParamsAsRight.Length)
-            {{
-                return false;
-            }}
-            for (int i = 0; i < marshalParamsAsLeft.Length; ++i)
-            {{
-                if (!Equals(marshalParamsAsLeft[i], marshalParamsAsRight[i]))
-                {{
-                    return false;
-                }}
-            }}
-            return true;
-        }}
-
-        private static bool Equals(MarshalAsAttribute? left, MarshalAsAttribute? right)
+        internal static bool Equals(MarshalAsAttribute? left, MarshalAsAttribute? right)
         {{
             if (left is null)
             {{
@@ -237,6 +209,30 @@ namespace {Constants.RootNamespace}
                 left.MarshalType == right.MarshalType &&
                 left.MarshalTypeRef == right.MarshalTypeRef &&
                 left.MarshalCookie == right.MarshalCookie;
+        }}
+
+        internal static bool PartiallyEquals(MarshalAsAttribute?[]? left, MarshalAsAttribute?[]? right)
+        {{
+            if (left is null)
+            {{
+                return right is null;
+            }}
+            int i = 0;
+            for (int len = Math.Min(left.Length, right?.Length ?? 0); i < len; ++i)
+            {{
+                if (!Equals(left[i], right![i]))
+                {{
+                    return false;
+                }}
+            }}
+            for ( ; i < left.Length; ++i)
+            {{
+                if (!Equals(left[i], null))
+                {{
+                    return false;
+                }}
+            }}
+            return true;
         }}
     }}
 {ConcreteClassDefinitions}{InterfaceImplementations}}}


### PR DESCRIPTION
Removed diagnostic NGD1002 (`marshalParamsAs argument must be array of correct length`) reported when `marshalParamsAs` argument (e.g., to `FromAction` or `FromFunctionPointer`) contained a different number of elements than arguments needed for the native generic delegate (e.g., the number of arguments passed to `Invoke`).

If excessive `MarshalAsAttribute` elements are provided in the array argument, they are ignored. If too few elements are provided, then the remainder are treated as `null`.

Closes #5.