### PR TITLE
Implement runtime fallbacks feature

### DIFF
--- a/AnalyzerReleases.Unshipped.md
+++ b/AnalyzerReleases.Unshipped.md
@@ -6,5 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 NGD1001 | Usage | Error | Diagnostics
-NGD1002 | Usage | Error | Diagnostics
 NGD1003 | Usage | Error | Diagnostics

--- a/Diagnostics.cs
+++ b/Diagnostics.cs
@@ -15,16 +15,6 @@ namespace Monkeymoto.NativeGenericDelegates
                 true
             );
 
-        public static readonly DiagnosticDescriptor NGD1002_InvalidCallingConventionArgument = new
-        (
-            "NGD1002",
-            "NGD1002: Invalid CallingConvention argument",
-            "CallingConvention argument must be literal or static readonly field",
-            "Usage",
-            DiagnosticSeverity.Error,
-            true
-        );
-
         public static readonly DiagnosticDescriptor NGD1003_MarshalAsArgumentSpreadElementNotSupported = new
         (
             "NGD1003",


### PR DESCRIPTION
This PR will implement the `Runtime fallbacks` feature as described in #21, and fixes #24.

### Runtime fallbacks

- [x] `CallingConvention callingConvention`
- [ ] `MarshalAsAttribute? marshalReturnAs`
- [ ] `MarshalAsAttribute?[]? marshalParamsAs`
- [ ] Remove diagnostics
    - [ ] `NGD1001` - Invalid `MarshalAsAttribute` argument (not statically parsable)
    - [x] `NGD1002` - Invalid `CallingConvention` argument
    - [ ] `NGD1003` - Invalid `MarshalAsAttribute[]` argument (spread element is not supported)