### PR TITLE
Implement runtime fallbacks for `CallingConvention` parameter

### DIFF
--- a/AnalyzerReleases.Unshipped.md
+++ b/AnalyzerReleases.Unshipped.md
@@ -6,5 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 NGD1001 | Usage | Error | Diagnostics
-NGD1002 | Usage | Error | Diagnostics
 NGD1003 | Usage | Error | Diagnostics

--- a/Diagnostics.cs
+++ b/Diagnostics.cs
@@ -15,16 +15,6 @@ namespace Monkeymoto.NativeGenericDelegates
                 true
             );
 
-        public static readonly DiagnosticDescriptor NGD1002_InvalidCallingConventionArgument = new
-        (
-            "NGD1002",
-            "NGD1002: Invalid CallingConvention argument",
-            "CallingConvention argument must be literal or static readonly field",
-            "Usage",
-            DiagnosticSeverity.Error,
-            true
-        );
-
         public static readonly DiagnosticDescriptor NGD1003_MarshalAsArgumentSpreadElementNotSupported = new
         (
             "NGD1003",


### PR DESCRIPTION
As originally described in #21 and #26, this allows for the `CallingConvention` parameter to be parsed at runtime if the supplied argument is not a compile-time constant expression. This incurs a (*very*) small performance hit when the implementation class instance is created, but removes the restriction on the argument value at compile-time.