### PR TITLE
Implement unmanaged interface APIs

### DIFF
--- a/Constants.Actions.cs
+++ b/Constants.Actions.cs
@@ -1,4 +1,6 @@
-﻿namespace Monkeymoto.NativeGenericDelegates
+﻿using System.Linq;
+
+namespace Monkeymoto.NativeGenericDelegates
 {
     internal static partial class Constants
     {
@@ -24,11 +26,37 @@
                 $"{RootNamespace}.INativeAction`13",
                 $"{RootNamespace}.INativeAction`14",
                 $"{RootNamespace}.INativeAction`15",
-                $"{RootNamespace}.INativeAction`16"
+                $"{RootNamespace}.INativeAction`16",
+                "",
+                $"{RootNamespace}.IUnmanagedAction`2",
+                $"{RootNamespace}.IUnmanagedAction`4",
+                $"{RootNamespace}.IUnmanagedAction`6",
+                $"{RootNamespace}.IUnmanagedAction`8",
+                $"{RootNamespace}.IUnmanagedAction`10",
+                $"{RootNamespace}.IUnmanagedAction`12",
+                $"{RootNamespace}.IUnmanagedAction`14",
+                $"{RootNamespace}.IUnmanagedAction`16",
+                $"{RootNamespace}.IUnmanagedAction`18",
+                $"{RootNamespace}.IUnmanagedAction`20",
+                $"{RootNamespace}.IUnmanagedAction`22",
+                $"{RootNamespace}.IUnmanagedAction`24",
+                $"{RootNamespace}.IUnmanagedAction`26",
+                $"{RootNamespace}.IUnmanagedAction`28",
+                $"{RootNamespace}.IUnmanagedAction`30",
+                $"{RootNamespace}.IUnmanagedAction`32"
             ];
 
             public static readonly string[] QualifiedTypeParameters = Constants.QualifiedTypeParameters;
             public static readonly string[] TypeParameters = Constants.TypeParameters;
+
+            public static readonly string[] UnmanagedConstraints =
+            [
+                .. AntiConstraints.Select(static x =>
+                {
+                    var unmanaged = x.Replace(": allows", ": unmanaged, allows").Replace('T', 'U');
+                    return $"{x}{unmanaged}";
+                })
+            ];
         }
     }
 }

--- a/Constants.Funcs.cs
+++ b/Constants.Funcs.cs
@@ -31,7 +31,24 @@ namespace Monkeymoto.NativeGenericDelegates
                 $"{RootNamespace}.INativeFunc`14",
                 $"{RootNamespace}.INativeFunc`15",
                 $"{RootNamespace}.INativeFunc`16",
-                $"{RootNamespace}.INativeFunc`17"
+                $"{RootNamespace}.INativeFunc`17",
+                $"{RootNamespace}.IUnmanagedFunc`2",
+                $"{RootNamespace}.IUnmanagedFunc`4",
+                $"{RootNamespace}.IUnmanagedFunc`6",
+                $"{RootNamespace}.IUnmanagedFunc`8",
+                $"{RootNamespace}.IUnmanagedFunc`10",
+                $"{RootNamespace}.IUnmanagedFunc`12",
+                $"{RootNamespace}.IUnmanagedFunc`14",
+                $"{RootNamespace}.IUnmanagedFunc`16",
+                $"{RootNamespace}.IUnmanagedFunc`18",
+                $"{RootNamespace}.IUnmanagedFunc`20",
+                $"{RootNamespace}.IUnmanagedFunc`22",
+                $"{RootNamespace}.IUnmanagedFunc`24",
+                $"{RootNamespace}.IUnmanagedFunc`26",
+                $"{RootNamespace}.IUnmanagedFunc`28",
+                $"{RootNamespace}.IUnmanagedFunc`30",
+                $"{RootNamespace}.IUnmanagedFunc`32",
+                $"{RootNamespace}.IUnmanagedFunc`34"
             ];
 
             public static readonly string[] QualifiedTypeParameters =
@@ -44,6 +61,15 @@ namespace Monkeymoto.NativeGenericDelegates
             [
                 "TResult",
                 .. Constants.TypeParameters.Skip(1).Select(x => $"{x}, TResult")
+            ];
+
+            public static readonly string[] UnmanagedConstraints =
+            [
+                .. AntiConstraints.Select(static x =>
+                {
+                    var unmanaged = x.Replace(": allows", ": unmanaged, allows").Replace('T', 'U');
+                    return $"{x}{unmanaged}";
+                })
             ];
         }
     }

--- a/Constants.cs
+++ b/Constants.cs
@@ -60,13 +60,6 @@ namespace Monkeymoto.NativeGenericDelegates
         private const string AntiConstraint_T1_T16 =
             $"{AntiConstraint_T1_T15}{NewLineIndent2}where T16 : allows ref struct";
 
-        public static readonly string[] InterceptorAntiConstraints =
-        [
-            .. AntiConstraints.Select(static x => x.Replace("    where T", "        where X").Replace('T', 'X')),
-            $"{AntiConstraint_T1_T16.Replace("    where T", "        where X")
-                .Replace('T', 'X')}{NewLineIndent2}where X17 : allows ref struct"
-        ];
-
         public static readonly string[] Arguments =
         [
             Arguments_T0,
@@ -114,11 +107,6 @@ namespace Monkeymoto.NativeGenericDelegates
 
         public const string IMarshallerInterfaceName = "IMarshaller";
         public const string IMarshallerMetadataName = $"{RootNamespace}.{IMarshallerInterfaceName}`1";
-
-        /// <summary>
-        /// Returns the total number of interfaces per category (Action or Func).
-        /// </summary>
-        public const int InterfaceSymbolCountPerCategory = 17;
 
         /// <summary>
         /// Returns a newline for a source text string.
@@ -218,10 +206,27 @@ namespace Monkeymoto.NativeGenericDelegates
         private const string TypeParameters_T1_T15 = $"{TypeParameters_T1_T14}, T15";
         private const string TypeParameters_T1_T16 = $"{TypeParameters_T1_T15}, T16";
 
+        public static readonly string[] InterceptorTypeConstraints =
+        [
+            .. AntiConstraints.Select(static x => x.Replace("    where T", "        where X").Replace('T', 'X')),
+            $"{AntiConstraint_T1_T16.Replace("    where T", "        where X")
+                .Replace('T', 'X')}{NewLineIndent3}where X17 : allows ref struct"
+        ];
+
+        public static readonly string[] InterceptorUnmanagedTypeConstraints =
+        [
+            .. InterceptorTypeConstraints.Select(static x => $"{x.Replace("X", "XT")}{x.Replace("X", "XU").Replace(": allows", ": unmanaged, allows")}")
+        ];
+
         public static readonly string[] InterceptorTypeParameters =
         [
             .. TypeParameters.Select(static x => x.Replace('T', 'X')),
             $"{TypeParameters_T1_T16.Replace('T', 'X')}, X17"
+        ];
+
+        public static readonly string[] InterceptorUnmanagedTypeParameters =
+        [
+            .. InterceptorTypeParameters.Select(static x => $"{x.Replace("X", "XT")}, {x.Replace("X", "XU")}")
         ];
 
         private static readonly string[] QualifiedTypeParameters =

--- a/Generator.cs
+++ b/Generator.cs
@@ -52,7 +52,14 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace {Constants.RootNamespace}
-{{"
+{{
+    file static class NativeGenericDelegates
+    {{
+        public static CallingConvention PlatformDefaultCallingConvention =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                CallingConvention.StdCall :
+                CallingConvention.Cdecl;
+    }}"
                     );
                     foreach (var implementationClass in implementationClasses)
                     {

--- a/MethodReference.cs
+++ b/MethodReference.cs
@@ -80,6 +80,7 @@ namespace Monkeymoto.NativeGenericDelegates
                 (
                     marshaller,
                     interfaceDescriptor,
+                    methodDescriptor,
                     invocationExpression,
                     semanticModel,
                     cancellationToken


### PR DESCRIPTION
As originally described in #21, this adds additional interfaces `IUnmanagedAction` and `IUnmanagedFunc` that derive from `INativeAction` or `INativeFunc`, respectively. These new interfaces explicitly require the `unsafe` keyword, so the compilation must use the `/unsafe` compiler switch **and** define a constant `UNSAFE` to use the new interfaces.

The new interfaces have twice as many generic type arguments as the base interfaces, with each type parameter `Tn` having a matching type parameter `Un`. Each `U`-prefixed type argument represents a [native function pointer](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers) argument type, and has an `unmanaged` generic type constraint.

To represent a method that in managed code takes a single `string` parameter, you might then use this interface:

```C#
var action = IUnmanagedAction<string, nint>.FromFunctionPointer(...);
```

`nint` here represents the native method's argument of the matching ordinal position.

*The generic type parameters include **all** of the managed type arguments first, then the unmanaged type arguments.*

The benefit behind this new API is that you can directly work with native function pointers. Methods marked with the `UnmanagedCallersOnlyAttribute` can be implicitly converted to a native function pointer using the `&` (address-of) operator, but this works with other native function pointers as well.

```C#
[UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
public static void UnmanagedPrint(nint message)
{
    var str = Marshal.PtrToStringUni(message);
    Console.WriteLine(str);
}

// ...

var action = IUnmanagedAction<string, nint>.FromFunctionPointer(&UnmanagedPrint);
```

The calling convention is read directly from the function pointer's signature, so here this will be `CallingConvention.Cdecl`. Overwriting the calling convention for native function pointers is not supported by the API.

Creating the managed object is only half of the battle. Native function pointers are only useful when you invoke them directly:

```C#
var str = Marshal.StringToCoTaskMemUni("Hello World!");
action.AsCdeclPtr(str);
Marshal.FreeCoTaskMem(str);
```

Because we are invoking the function pointer directly, the argument has the type `nint`. Here, we use the `Marshal` class to allocate and free memory, but other strategies exist. You lose the benefit of built-in marshalling when invoking the function pointer directly, but the invocation is direct - there is no overhead from the managed runtime, garbage collector, etc.

Properties are exposed for `AsCdeclPtr`, `AsStdCallPtr`, and `AsThisCallPtr`. These properties do not do any runtime checks, except when the factory method was called with `CallingConvention.Winapi`, which will check the [platform default calling convention](https://learn.microsoft.com/en-us/dotnet/standard/native-interop/calling-conventions#platform-default-calling-convention) at runtime (using x86-platform rules for the default; non-x86 platforms don't have an explicit default).

You can fall back to the `INativeAction`/`INativeFunc` interface if you don't want to carry the full type parameter list for both the managed and unmanaged type arguments, but casting back will require the full type argument list. Objects created using the `INativeAction`/`INativeFunc` interface factory methods will not implement the `IUnmanagedAction`/`IUnmanagedFunc` interface.