### PR TITLE
Check marshaller in open generic interceptors

### DIFF
--- a/Constants.cs
+++ b/Constants.cs
@@ -137,6 +137,7 @@ namespace Monkeymoto.NativeGenericDelegates
         public const string NewLineIndent1 = $"{NewLine}    ";
         public const string NewLineIndent2 = $"{NewLineIndent1}    ";
         public const string NewLineIndent3 = $"{NewLineIndent2}    ";
+        public const string NewLineIndent4 = $"{NewLineIndent3}    ";
         public const string SourceFileName = RootNamespace + ".g.cs";
 
         public static readonly string[] Parameters =

--- a/MarshalInfo.cs
+++ b/MarshalInfo.cs
@@ -14,6 +14,7 @@ namespace Monkeymoto.NativeGenericDelegates
     {
         private readonly int hashCode;
 
+        public string? MarshallerType { get; }
         public IReadOnlyList<string?>? MarshalParamsAs { get; }
         public string? MarshalReturnAs { get; }
         public CallingConvention? StaticCallingConvention { get; }
@@ -117,7 +118,8 @@ namespace Monkeymoto.NativeGenericDelegates
                 callingConventionOp,
                 marshalMapOp,
                 marshalParamsAsOp,
-                marshalReturnAsOp
+                marshalReturnAsOp,
+                marshaller
             );
         }
 
@@ -172,6 +174,7 @@ namespace Monkeymoto.NativeGenericDelegates
             StaticCallingConvention = GetStaticCallingConvention(operation);
             hashCode = Hash.Combine
             (
+                MarshallerType,
                 MarshalParamsAs,
                 MarshalReturnAs,
                 StaticCallingConvention
@@ -184,10 +187,12 @@ namespace Monkeymoto.NativeGenericDelegates
             IFieldReferenceOperation? callingConventionOp,
             IObjectCreationOperation? marshalMapCreation,
             IObjectCreationOperation? marshalParamsAsCreation,
-            IObjectCreationOperation? marshalReturnAsCreation
+            IObjectCreationOperation? marshalReturnAsCreation,
+            INamedTypeSymbol marshaller
         )
         {
             StaticCallingConvention = GetStaticCallingConvention(callingConventionOp);
+            MarshallerType = $"typeof({marshaller.ToDisplayString()})";
             MarshalParamsAs =
                 Parser.GetMarshalParamsAs(marshalParamsAsCreation, interfaceDescriptor.InvokeParameterCount);
             MarshalReturnAs = Parser.GetMarshalReturnAs(marshalReturnAsCreation);
@@ -225,6 +230,7 @@ namespace Monkeymoto.NativeGenericDelegates
             }
             hashCode = Hash.Combine
             (
+                MarshallerType,
                 MarshalParamsAs,
                 MarshalReturnAs,
                 StaticCallingConvention
@@ -233,7 +239,7 @@ namespace Monkeymoto.NativeGenericDelegates
 
         public override bool Equals(object? obj) => obj is MarshalInfo other && Equals(other);
         public bool Equals(MarshalInfo? other) =>
-            (other is not null) &&
+            (other is not null) && (MarshallerType == other.MarshallerType) &&
             (MarshalParamsAs?.SequenceEqual(other.MarshalParamsAs) ?? other.MarshalParamsAs is null) &&
             (MarshalReturnAs == other.MarshalReturnAs) && (StaticCallingConvention == other.StaticCallingConvention);
         public override int GetHashCode() => hashCode;

--- a/OpenGenericInterceptors.cs
+++ b/OpenGenericInterceptors.cs
@@ -76,9 +76,21 @@ namespace Monkeymoto.NativeGenericDelegates
                 {
                     var method = kv.Value[i].Method;
                     var typeArguments = method.ContainingInterface.TypeArguments;
+                    var marshallerType = kv.Value[i].MarshalInfo.MarshallerType;
                     if (typeArguments.Count == 1)
                     {
-                        _ = sb.Append($"            if (typeof(X) == typeof({typeArguments[0]}))");
+                        if (marshallerType is null)
+                        {
+                            _ = sb.Append($"            if (typeof(X) == typeof({typeArguments[0]}))");
+                        }
+                        else
+                        {
+                            _ = sb.Append
+                            (
+                                $"            if ((typeof(X) == typeof({typeArguments[0]
+                                    })) && (typeof(XMarshaller) == {marshallerType}))"
+                            );
+                        }
                     }
                     else
                     {
@@ -89,6 +101,10 @@ namespace Monkeymoto.NativeGenericDelegates
                             if (k != typeArguments.Count)
                             {
                                 _ = sb.AppendLine(" &&");
+                            }
+                            else if (marshallerType is not null)
+                            {
+                                _ = sb.AppendLine($" &&{Constants.NewLineIndent4}(typeof(XMarshaller) == {marshallerType})");
                             }
                         }
                         _ = sb.Append("            )");


### PR DESCRIPTION
Fixes #34.

Simply checking the generic type argument `TMarshaller` *is* actually sufficient here, because the only value that can be specified without the generic type argument is the `CallingConvention`. Handling the calling convention at runtime is already a supported scenario.